### PR TITLE
Corrigindo middleware checkUserExist

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function checkUserExist(req, res, next) {
   const { id } = req.params;
   const project = projects.find(p => p.id == id);
 
-  if (!req.body.projects) {
+  if (!project) {
     return res.status(400).json({ error: "not found" });
   }
   return next();


### PR DESCRIPTION
Nesse middleware, é preciso verificar se o projeto existe. Caso não, a requisição não passa por ele e dá sempre erro.